### PR TITLE
Bump graphql version and move it into dev & peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/GraphQLCollege/graphql-postgres-subscriptions.git"
   },
   "peerDependencies": {
-    "graphql": "^0.13.2 || ^14.0.2"
+    "graphql": "^0.10.5 || ^0.11.3 || ^0.12.0 || ^0.13.0 || ^14.0.0"
   },
   "dependencies": {
     "graphql-subscriptions": "^0.5.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-postgres-subscriptions",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "index.js",
   "license": "MIT",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -10,14 +10,17 @@
     "type": "git",
     "url": "https://github.com/GraphQLCollege/graphql-postgres-subscriptions.git"
   },
+  "peerDependencies": {
+    "graphql": "^0.13.2 || ^14.0.2"
+  },
   "dependencies": {
-    "graphql": "^0.13.2",
     "graphql-subscriptions": "^0.5.8",
     "iterall": "^1.2.2",
     "pg": "^7.4.1",
     "pg-ipc": "^1.0.4"
   },
   "devDependencies": {
+    "graphql": "^14.0.2",
     "jest": "^22.4.3"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1091,11 +1091,11 @@ graphql-subscriptions@^0.5.8:
   dependencies:
     iterall "^1.2.1"
 
-graphql@^0.13.2:
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.2.tgz#4c740ae3c222823e7004096f832e7b93b2108270"
+graphql@^14.0.2:
+  version "14.0.2"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.0.2.tgz#7dded337a4c3fd2d075692323384034b357f5650"
   dependencies:
-    iterall "^1.2.1"
+    iterall "^1.2.2"
 
 growly@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
As other tools in this space are doing, it's quite handy to specify `graphql` as a peerDependency, to avoid duplicate instances of it.

E.g. https://github.com/apollographql/graphql-subscriptions/blob/master/package.json#L13-L15

or 

https://github.com/apollographql/graphql-tools/blob/master/package.json#L57-L59