### PR TITLE
Added a `commonMessageHandler` to share DataLoaders between subscribers

### DIFF
--- a/event-emitter-to-async-iterator.js
+++ b/event-emitter-to-async-iterator.js
@@ -2,7 +2,7 @@
 const { $$asyncIterator } = require("iterall");
 const { EventEmitter } = require("events");
 
-function eventEmitterAsyncIterator(eventEmitter, eventsNames) {
+function eventEmitterAsyncIterator(eventEmitter, eventsNames, commonMessageHandler = message => message) {
   const pullQueue = [];
   const pushQueue = [];
   const eventsArray =
@@ -10,10 +10,11 @@ function eventEmitterAsyncIterator(eventEmitter, eventsNames) {
   let listening = true;
 
   const pushValue = ({ payload: event }) => {
+		const value = commonMessageHandler(event);
     if (pullQueue.length !== 0) {
-      pullQueue.shift()({ value: event, done: false });
+      pullQueue.shift()({ value, done: false });
     } else {
-      pushQueue.push(event);
+      pushQueue.push(value);
     }
   };
 

--- a/event-emitter-to-async-iterator.js
+++ b/event-emitter-to-async-iterator.js
@@ -10,7 +10,7 @@ function eventEmitterAsyncIterator(eventEmitter, eventsNames, commonMessageHandl
   let listening = true;
 
   const pushValue = ({ payload: event }) => {
-		const value = commonMessageHandler(event);
+    const value = commonMessageHandler(event);
     if (pullQueue.length !== 0) {
       pullQueue.shift()({ value, done: false });
     } else {

--- a/postgres-pubsub.js
+++ b/postgres-pubsub.js
@@ -6,7 +6,7 @@ const {
 } = require("./event-emitter-to-async-iterator");
 
 class PostgresPubSub extends PubSub {
-  constructor(options = {}) {
+	constructor(options = {}, commonMessageHandler = message => message) {
     super();
     this.client = options.client || new Client(options);
     if (!options.client) {
@@ -15,6 +15,7 @@ class PostgresPubSub extends PubSub {
     this.ee = new pgIPC(this.client);
     this.subscriptions = {};
     this.subIdCounter = 0;
+		this.commonMessageHandler = commonMessageHandler;
   }
   publish(triggerName, payload) {
     this.ee.notify(triggerName, payload);
@@ -22,7 +23,7 @@ class PostgresPubSub extends PubSub {
   }
   subscribe(triggerName, onMessage) {
     const callback = message => {
-      onMessage(message instanceof Error ? message : message.payload);
+      onMessage(message instanceof Error ? message : this.commonMessageHandler(message.payload));
     };
     this.ee.on(triggerName, callback);
     this.subIdCounter = this.subIdCounter + 1;
@@ -35,7 +36,7 @@ class PostgresPubSub extends PubSub {
     this.ee.removeListener(triggerName, onMessage);
   }
   asyncIterator(triggers) {
-    return eventEmitterAsyncIterator(this.ee, triggers);
+    return eventEmitterAsyncIterator(this.ee, triggers, this.commonMessageHandler);
   }
 }
 

--- a/postgres-pubsub.js
+++ b/postgres-pubsub.js
@@ -6,7 +6,7 @@ const {
 } = require("./event-emitter-to-async-iterator");
 
 class PostgresPubSub extends PubSub {
-	constructor(options = {}, commonMessageHandler = message => message) {
+  constructor(options = {}, commonMessageHandler = message => message) {
     super();
     this.client = options.client || new Client(options);
     if (!options.client) {
@@ -15,7 +15,7 @@ class PostgresPubSub extends PubSub {
     this.ee = new pgIPC(this.client);
     this.subscriptions = {};
     this.subIdCounter = 0;
-		this.commonMessageHandler = commonMessageHandler;
+    this.commonMessageHandler = commonMessageHandler;
   }
   publish(triggerName, payload) {
     this.ee.notify(triggerName, payload);

--- a/postgres-pubsub.test.js
+++ b/postgres-pubsub.test.js
@@ -142,7 +142,7 @@ describe("PostgresPubSub", () => {
     const ps = new PostgresPubSub({ client });
     const iterator = ps.asyncIterator(eventName);
 
-		const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+    const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 
     iterator
       .next()
@@ -150,20 +150,20 @@ describe("PostgresPubSub", () => {
         expect(result).not.toBeUndefined();
         expect(result.value).not.toBeUndefined();
         expect(result.done).toBe(false);
-			});
+      });
 
     ps.publish(eventName, { test: true });
 
-		await delay(0);
+    await delay(0);
 
     iterator.next().then(result => {
       expect(result).not.toBeUndefined();
       expect(result.value).toBeUndefined();
       expect(result.done).toBe(true);
       done();
-		});
+    });
 
-		await delay(0);
+    await delay(0);
 
     iterator.return();
 
@@ -172,8 +172,8 @@ describe("PostgresPubSub", () => {
 
   test("AsyncIterator transforms messages using commonMessageHandler", done => {
     const eventName = "test";
-		const commonMessageHandler = message => ({ transformed: message });
-		const ps = new PostgresPubSub({ client }, commonMessageHandler);
+    const commonMessageHandler = message => ({ transformed: message });
+    const ps = new PostgresPubSub({ client }, commonMessageHandler);
     const iterator = ps.asyncIterator(eventName);
 
     iterator
@@ -182,14 +182,14 @@ describe("PostgresPubSub", () => {
         expect(result).not.toBeUndefined();
         expect(result.value).toEqual({ transformed: { test: true } });
         expect(result.done).toBe(false);
-				done();
-			});
+        done();
+      });
 
     ps.publish(eventName, { test: true });
   });
 
-	test("PostgresPubSub transforms messages using commonMessageHandler", function(done) {
-		const commonMessageHandler = message => ({ transformed: message });
+  test("PostgresPubSub transforms messages using commonMessageHandler", function(done) {
+    const commonMessageHandler = message => ({ transformed: message });
     const ps = new PostgresPubSub({ client }, commonMessageHandler);
     ps.subscribe("transform", payload => {
       expect(payload).toEqual({ transformed: { test: true } });

--- a/postgres-pubsub.test.js
+++ b/postgres-pubsub.test.js
@@ -169,4 +169,35 @@ describe("PostgresPubSub", () => {
 
     ps.publish(eventName, { test: true });
   });
+
+  test("AsyncIterator transforms messages using commonMessageHandler", done => {
+    const eventName = "test";
+		const commonMessageHandler = message => ({ transformed: message });
+		const ps = new PostgresPubSub({ client }, commonMessageHandler);
+    const iterator = ps.asyncIterator(eventName);
+
+    iterator
+      .next()
+      .then(result => {
+        expect(result).not.toBeUndefined();
+        expect(result.value).toEqual({ transformed: { test: true } });
+        expect(result.done).toBe(false);
+				done();
+			});
+
+    ps.publish(eventName, { test: true });
+  });
+
+	test("PostgresPubSub transforms messages using commonMessageHandler", function(done) {
+		const commonMessageHandler = message => ({ transformed: message });
+    const ps = new PostgresPubSub({ client }, commonMessageHandler);
+    ps.subscribe("transform", payload => {
+      expect(payload).toEqual({ transformed: { test: true } });
+      done();
+    }).then(() => {
+      const succeed = ps.publish("transform", { test: true });
+      expect(succeed).toBe(true);
+    });
+  });
+
 });

--- a/postgres-pubsub.test.js
+++ b/postgres-pubsub.test.js
@@ -137,10 +137,12 @@ describe("PostgresPubSub", () => {
     ps.publish(eventName, { test: true });
   });
 
-  test("AsyncIterator should not trigger event on asyncIterator already returned", done => {
+  test("AsyncIterator should not trigger event on asyncIterator already returned", async done => {
     const eventName = "test";
     const ps = new PostgresPubSub({ client });
     const iterator = ps.asyncIterator(eventName);
+
+		const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 
     iterator
       .next()
@@ -148,16 +150,20 @@ describe("PostgresPubSub", () => {
         expect(result).not.toBeUndefined();
         expect(result.value).not.toBeUndefined();
         expect(result.done).toBe(false);
-      });
+			});
 
     ps.publish(eventName, { test: true });
+
+		await delay(0);
 
     iterator.next().then(result => {
       expect(result).not.toBeUndefined();
       expect(result.value).toBeUndefined();
       expect(result.done).toBe(true);
       done();
-    });
+		});
+
+		await delay(0);
 
     iterator.return();
 


### PR DESCRIPTION
Thanks for the `graphql-postgres-subscriptions` library! It does exactly what I need it to do, with one omission: I could not find a way to share a DataLoader between the different subscribers of a message.

#### Use case
The messages we publish mainly contain the primary keys of modified records in a database. This is to avoid leaking personal information, and also to avoid hitting the 9000 character limit of a Postgres notification.
The resolver then loads the record based on the primary key, but this record is the same for all subscribers. It therefore makes sense to share a DataLoader to avoid hitting the database multiple times.

#### Solution
The `graphql-google-pubsub` library handles this by adding an optional `commonMessageHandler` parameter to the constructor of the engine (see https://github.com/axelspringer/graphql-google-pubsub/blob/master/README.md#commonmessagehandler)

I added this same pattern to the `graphql-postgres-subscriptions` library, and added some basic tests and documentation for usage.

Please let me know if this is fit to be merged, or if you would like to see some other changes made to this.

I also fixed one of the existing tests that was occasionally failing by adding an intentional delay.